### PR TITLE
Support Podium v4

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -2,7 +2,7 @@
 
 const HapiPodlet = require('../');
 const Podlet = require('@podium/podlet');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const app = Hapi.Server({
     host: 'localhost',

--- a/lib/podlet-plugin.js
+++ b/lib/podlet-plugin.js
@@ -4,12 +4,22 @@ const { HttpIncoming } = require('@podium/utils');
 const utils = require('@podium/utils');
 const pkg = require('../package.json');
 
-// Hapi v17 or newer
-
 const PodiumPodletHapiPlugin = class PodiumPodletHapiPlugin {
     constructor() {
+        Object.defineProperty(this, 'name', {
+            value: 'PodiumPodletHapiPlugin',
+            enumerable: true,
+        });
+
         Object.defineProperty(this, 'pkg', {
             value: pkg,
+            enumerable: true,
+        });
+
+        Object.defineProperty(this, 'requirements', {
+            value: {
+                hapi: '>=17.0.0'
+            },
             enumerable: true,
         });
     }
@@ -20,12 +30,21 @@ const PodiumPodletHapiPlugin = class PodiumPodletHapiPlugin {
 
     register(server, podlet) {
         // Run parsers on request and store state object on request.app.podium
+        // Do proxying if path is matching a proxy path
         server.ext({
             type: 'onRequest',
             method: async (request, h) => {
                 const { req, res } = request.raw;
                 const incoming = new HttpIncoming(req, res, request.app.params);
-                request.app.podium = await podlet.process(incoming);
+                request.app.podium = await podlet.process(incoming)
+
+                // If "incoming.proxy" is true, the proxy did proxy.
+                // Abandon the request.
+                if (request.app.podium.proxy) {
+                    return h.abandon;
+                }
+
+                // There was nothing to proxy. Continue the request.
                 return h.continue;
             },
         });
@@ -45,36 +64,8 @@ const PodiumPodletHapiPlugin = class PodiumPodletHapiPlugin {
         // Decorate response with .podiumSend() method
         // eslint-disable-next-line func-names
         server.decorate('toolkit', 'podiumSend', function(fragment) {
-            return this.request.app.podium.render(fragment);
+            return podlet.render(this.request.app.podium, fragment);
         });
-
-        // Mount proxy route
-        const pathname = utils.pathnameBuilder(
-            podlet.httpProxy.pathname,
-            podlet.httpProxy.prefix,
-            '/{path*}',
-        );
-        server.route([
-            {
-                method: '*',
-                path: pathname,
-                handler: async (request, h) => {
-                    const incoming = await podlet.httpProxy.process(
-                        request.app.podium,
-                    );
-
-                    // If a HttpIncoming object is returned, there was
-                    // nothing to proxy. Continue the request.
-                    if (incoming) {
-                        return h.continue;
-                    }
-
-                    // If "undefined" was not returned, the proxy did proxy.
-                    // Abandon the request.
-                    return h.abandon;
-                },
-            },
-        ]);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
   },
   "author": "Trygve Lie",
   "dependencies": {
-    "@podium/utils": "3.1.2"
+    "@podium/utils": "4.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.12.1",
+    "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-config-prettier": "^4.0.0",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "prettier": "^1.16.1",
-    "tap": "^14.2.2",
-    "@podium/podlet": "3.0.3",
-    "hapi": "^18.1.0"
+    "eslint-config-prettier": "^5.0.0",
+    "eslint-plugin-import": "^2.17.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "prettier": "^1.18.2",
+    "tap": "^14.2.3",
+    "@podium/podlet": "4.0.1",
+    "@hapi/hapi": "^18.1.0"
   }
 }

--- a/test/podlet-plugin.js
+++ b/test/podlet-plugin.js
@@ -1,7 +1,182 @@
+/* eslint-disable no-param-reassign */
+
 'use strict';
 
+const { URL } = require('url');
+const Podlet = require('@podium/podlet');
+const Hapi = require('@hapi/hapi');
+const http = require('http');
 const tap = require('tap');
-const Plugin = require('../');
+
+const HapiPodlet = require('../');
+
+class Server {
+    constructor(options = {}) {
+        this.app = Hapi.Server({
+            host: 'localhost',
+            port: 0,
+        });
+
+        const podlet = new Podlet(
+            Object.assign(
+                {
+                    pathname: '/',
+                    fallback: '/fallback',
+                    version: '2.0.0',
+                    name: 'podletContent',
+                },
+                options,
+            ),
+        );
+
+        podlet.view((incoming, fragment) => {
+            return `## ${fragment} ##`;
+        });
+
+        podlet.defaults({
+            locale: 'nb-NO',
+        });
+
+        this.app.register({
+            plugin: new HapiPodlet(),
+            options: podlet,
+        });
+
+        this.app.route({
+            method: 'GET',
+            path: podlet.content(),
+            handler: (request, h) => {
+                if (request.app.podium.context.locale === 'nb-NO') {
+                    return h.podiumSend('nb-NO');
+                }
+                if (request.app.podium.context.locale === 'en-NZ') {
+                    return h.podiumSend('en-NZ');
+                }
+                return h.podiumSend('en-US');
+            },
+        });
+
+        this.app.route({
+            method: 'GET',
+            path: podlet.fallback(),
+            handler: (request, h) => {
+                return h.podiumSend('fallback');
+            },
+        });
+
+        this.app.route({
+            method: 'GET',
+            path: podlet.manifest(),
+            handler: (request, h) => JSON.stringify(podlet),
+        });
+
+        // Dummy endpoints for proxying
+        this.app.route({
+            method: 'GET',
+            path: '/public',
+            handler: (request, h) => 'GET proxy target',
+        });
+
+        this.app.route({
+            method: 'POST',
+            path: '/public',
+            handler: (request, h) => {
+                return 'POST proxy target';
+            },
+        });
+
+        this.app.route({
+            method: 'PUT',
+            path: '/public',
+            handler: (request, h) => 'PUT proxy target',
+        });
+
+        // 404 route
+        this.app.route({
+            method: '*',
+            path: '/{any*}',
+            handler: (request, h) => {
+                const response = h.response('Not found');
+                response.code(404);
+                response.header('Content-Type', 'text/plain');
+                return response;
+            },
+        });
+
+        // Proxy to the dummy endpoints
+        podlet.proxy({ target: '/public', name: 'localApi' });
+    }
+
+    listen() {
+        return new Promise((resolve, reject) => {
+            setTimeout(async () => {
+                try {
+                    await this.app.start();
+                    resolve(this.app.info.uri);
+                } catch (error) {
+                    reject(error);
+                }
+            }, 100);
+        });
+    }
+
+    close() {
+        return new Promise(resolve => {
+            setTimeout(async () => {
+                await this.app.stop();
+                resolve();
+            }, 100);
+        });
+    }
+}
+
+const request = (
+    { pathname = '/', address = '', headers = {}, method = 'GET' } = {},
+    payload,
+) => {
+    return new Promise((resolve, reject) => {
+        const url = new URL(pathname, address);
+
+        if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
+            headers = Object.assign(headers, {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Length': Buffer.byteLength(payload),
+            });
+        }
+
+        const options = {
+            hostname: url.hostname,
+            port: url.port,
+            path: url.pathname,
+            headers,
+            method,
+        };
+
+        const req = http
+            .request(options, res => {
+                const chunks = [];
+                res.on('data', chunk => {
+                    chunks.push(chunk);
+                });
+                res.on('end', () => {
+                    resolve({
+                        headers: res.headers,
+                        body: chunks.join(''),
+                    });
+                });
+            })
+            .on('error', error => {
+                reject(error);
+            });
+
+        if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
+            req.write(payload);
+        }
+
+        req.end();
+    });
+};
+
 
 /**
  * Constructor
@@ -10,11 +185,249 @@ const Plugin = require('../');
 tap.test(
     'Constructor() - object type - should be PodiumPodletHapiPlugin',
     t => {
-        const p = new Plugin();
+        const plugin = new HapiPodlet();
         t.equal(
-            Object.prototype.toString.call(p),
+            Object.prototype.toString.call(plugin),
             '[object PodiumPodletHapiPlugin]',
         );
+        t.end();
+    },
+);
+
+
+/**
+ * Generic tests
+ */
+
+tap.test(
+    'request "manifest" url - should return content of "manifest" url',
+    async t => {
+        const server = new Server();
+        const address = await server.listen();
+        const result = await request({ address, pathname: '/manifest.json' });
+        const parsed = JSON.parse(result.body);
+
+        t.equal(parsed.version, '2.0.0');
+        t.equal(parsed.fallback, '/fallback');
+        t.equal(parsed.content, '/');
+        t.equal(parsed.name, 'podletContent');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'request "content" url - development: false - should return default content of "content" url',
+    async t => {
+        const server = new Server({ development: false });
+        const address = await server.listen();
+        const result = await request({ address });
+
+        t.equal(result.body, 'en-US');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'request "content" url - development: true - should return context aware content of "content" url',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request({ address });
+
+        t.equal(result.body, '## nb-NO ##');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'request "content" url - development: true - should return development mode decorated content of "content" url',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request({ address });
+
+        t.equal(result.body, '## nb-NO ##');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'request "fallback" url - development: false - should return content of "fallback" url',
+    async t => {
+        const server = new Server();
+        const address = await server.listen();
+        const result = await request({ address, pathname: '/fallback' });
+
+        t.equal(result.body, 'fallback');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'request "fallback" url - development: false - should return development mode decorated content of "fallback" url',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request({ address, pathname: '/fallback' });
+
+        t.equal(result.body, '## fallback ##');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test('request "manifest" url - should have version header', async t => {
+    const server = new Server();
+    const address = await server.listen();
+    const result = await request({ address, pathname: '/manifest.json' });
+
+    t.equal(result.headers['podlet-version'], '2.0.0');
+
+    await server.close();
+    t.end();
+});
+
+tap.test('request "content" url - should have version header', async t => {
+    const server = new Server();
+    const address = await server.listen();
+    const result = await request({ address });
+
+    t.equal(result.headers['podlet-version'], '2.0.0');
+
+    await server.close();
+    t.end();
+});
+
+tap.test('request "fallback" url - should have version header', async t => {
+    const server = new Server();
+    const address = await server.listen();
+    const result = await request({ address, pathname: '/fallback' });
+
+    t.equal(result.headers['podlet-version'], '2.0.0');
+
+    await server.close();
+    t.end();
+});
+
+tap.test(
+    'request "content" url - set a context parameter - should alter content of "content" url based on context',
+    async t => {
+        const server = new Server();
+        const address = await server.listen();
+        const result = await request({
+            address,
+            headers: {
+                'podium-locale': 'en-NZ',
+            },
+        });
+
+        t.equal(result.body, 'en-NZ');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'GET "proxy" url - development: false - should not proxy content',
+    async t => {
+        const server = new Server();
+        const address = await server.listen();
+        const result = await request({
+            address,
+            pathname: '/podium-resource/podletContent/localApi',
+        });
+
+        t.equal(result.body, 'Not found');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'GET "proxy" url - development: true - should proxy content',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request({
+            address,
+            pathname: '/podium-resource/podletContent/localApi',
+        });
+
+        t.equal(result.body, 'GET proxy target');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'GET "proxy" url - development: true - should have version header',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request({
+            address,
+            pathname: '/podium-resource/podletContent/localApi',
+        });
+
+        t.equal(result.headers['podlet-version'], '2.0.0');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'POST to "proxy" url - development: true - should proxy content',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request(
+            {
+                address,
+                method: 'POST',
+                pathname: '/podium-resource/podletContent/localApi',
+            },
+            'payload',
+        );
+
+        t.equal(result.body, 'POST proxy target');
+
+        await server.close();
+        t.end();
+    },
+);
+
+tap.test(
+    'PUT to "proxy" url - development: true - should proxy content',
+    async t => {
+        const server = new Server({ development: true });
+        const address = await server.listen();
+        const result = await request(
+            {
+                address,
+                method: 'PUT',
+                pathname: '/podium-resource/podletContent/localApi',
+            },
+            'payload',
+        );
+
+        t.equal(result.body, 'PUT proxy target');
+
+        await server.close();
         t.end();
     },
 );


### PR DESCRIPTION
This makes this plugin support Podium v4. 

Most significant change here is that this now uses the exact same tests as the Fastify Podlet plugin which did catch an error with http POST in this module. This error is corrected.